### PR TITLE
A RequestIdentifier just need to be castable to string

### DIFF
--- a/spec/Tolerance/Bridge/Guzzle/RequestIdentifier/MiddlewareFactorySpec.php
+++ b/spec/Tolerance/Bridge/Guzzle/RequestIdentifier/MiddlewareFactorySpec.php
@@ -23,7 +23,7 @@ class MiddlewareFactorySpec extends ObjectBehavior
     function its_middleware_adds_the_header_to_the_request(RequestIdentifierResolver $resolver, RequestInterface $request)
     {
         $identifier = StringRequestIdentifier::fromString('1234');
-        $resolver->get()->shouldBeCalled()->willReturn($identifier);
+        $resolver->resolve()->shouldBeCalled()->willReturn($identifier);
 
         $request->withAddedHeader('X-Request-Id', '1234')->shouldBeCalled();
 

--- a/spec/Tolerance/Bridge/Monolog/RequestIdentifier/RequestIdentifierProcessorSpec.php
+++ b/spec/Tolerance/Bridge/Monolog/RequestIdentifier/RequestIdentifierProcessorSpec.php
@@ -20,8 +20,8 @@ class RequestIdentifierProcessorSpec extends ObjectBehavior
             'context' => [],
         ];
 
-        $identifier->get()->willReturn('1234');
-        $requestIdentifierResolver->get()->willReturn($identifier);
+        $identifier->__toString()->willReturn('1234');
+        $requestIdentifierResolver->resolve()->willReturn($identifier);
 
         $this($record)->shouldReturn([
             'context' => [

--- a/spec/Tolerance/RequestIdentifier/Resolver/StoredOrGeneratedResolverSpec.php
+++ b/spec/Tolerance/RequestIdentifier/Resolver/StoredOrGeneratedResolverSpec.php
@@ -25,7 +25,7 @@ class StoredOrGeneratedResolverSpec extends ObjectBehavior
     {
         $storage->getRequestIdentifier()->willReturn($identifier);
 
-        $this->get()->shouldReturn($identifier);
+        $this->resolve()->shouldReturn($identifier);
     }
 
     function it_generates_and_stores_the_identifier_if_nothing_in_storage(RequestIdentifierStorage $storage, RequestIdentifierGenerator $generator, RequestIdentifier $identifier)
@@ -34,6 +34,6 @@ class StoredOrGeneratedResolverSpec extends ObjectBehavior
         $storage->getRequestIdentifier()->willReturn(null);
         $storage->setRequestIdentifier($identifier)->shouldBeCalled();
 
-        $this->get()->shouldReturn($identifier);
+        $this->resolve()->shouldReturn($identifier);
     }
 }

--- a/spec/Tolerance/RequestIdentifier/StringRequestIdentifierSpec.php
+++ b/spec/Tolerance/RequestIdentifier/StringRequestIdentifierSpec.php
@@ -20,6 +20,6 @@ class StringRequestIdentifierSpec extends ObjectBehavior
 
     function it_returns_the_string()
     {
-        $this->get()->shouldReturn('foo');
+        $this->__toString()->shouldReturn('foo');
     }
 }

--- a/src/Tolerance/Bridge/Guzzle/RequestIdentifier/MiddlewareFactory.php
+++ b/src/Tolerance/Bridge/Guzzle/RequestIdentifier/MiddlewareFactory.php
@@ -34,9 +34,9 @@ class MiddlewareFactory
     {
         return function (callable $handler) {
             return function (RequestInterface $request, array $options) use ($handler) {
-                $identifier = $this->resolver->get();
+                $identifier = $this->resolver->resolve();
 
-                $request = $request->withAddedHeader($this->headerName, $identifier->get());
+                $request = $request->withAddedHeader($this->headerName, (string) $identifier);
 
                 return $handler($request, $options);
             };

--- a/src/Tolerance/Bridge/Monolog/RequestIdentifier/RequestIdentifierProcessor.php
+++ b/src/Tolerance/Bridge/Monolog/RequestIdentifier/RequestIdentifierProcessor.php
@@ -29,7 +29,7 @@ class RequestIdentifierProcessor
     public function __invoke(array $record)
     {
         $record['context']['tags'] = [
-            'request-identifier' => $this->requestIdentifierResolver->get()->get(),
+            'request-identifier' => (string) $this->requestIdentifierResolver->resolve(),
         ];
 
         return $record;

--- a/src/Tolerance/RequestIdentifier/RequestIdentifier.php
+++ b/src/Tolerance/RequestIdentifier/RequestIdentifier.php
@@ -5,9 +5,9 @@ namespace Tolerance\RequestIdentifier;
 interface RequestIdentifier
 {
     /**
-     * Get the string representation of the request UUID.
+     * Get the string representation of the request identifier.
      *
      * @return string
      */
-    public function get();
+    public function __toString();
 }

--- a/src/Tolerance/RequestIdentifier/Resolver/RequestIdentifierResolver.php
+++ b/src/Tolerance/RequestIdentifier/Resolver/RequestIdentifierResolver.php
@@ -11,5 +11,5 @@ interface RequestIdentifierResolver
      *
      * @return RequestIdentifier
      */
-    public function get();
+    public function resolve();
 }

--- a/src/Tolerance/RequestIdentifier/Resolver/StoredOrGeneratedResolver.php
+++ b/src/Tolerance/RequestIdentifier/Resolver/StoredOrGeneratedResolver.php
@@ -30,7 +30,7 @@ class StoredOrGeneratedResolver implements RequestIdentifierResolver
     /**
      * {@inheritdoc}
      */
-    public function get()
+    public function resolve()
     {
         if (null === ($identifier = $this->storage->getRequestIdentifier())) {
             $identifier = $this->generator->generate();

--- a/src/Tolerance/RequestIdentifier/StringRequestIdentifier.php
+++ b/src/Tolerance/RequestIdentifier/StringRequestIdentifier.php
@@ -29,7 +29,7 @@ class StringRequestIdentifier implements RequestIdentifier
     /**
      * {@inheritdoc}
      */
-    public function get()
+    public function __toString()
     {
         return $this->string;
     }


### PR DESCRIPTION
- A RequestIdentifier just need to be castable to string
- The resolver exposes a `resolve()` method instead of a `get()`